### PR TITLE
Changed ProgramOutputStdout to use a loop instead of an 'apply'

### DIFF
--- a/blueprints/netapp-cdot.js
+++ b/blueprints/netapp-cdot.js
@@ -1,6 +1,9 @@
 // NetApp Clustered Data-OnTap pluggable blueprint for UpGuard
 // Please contact UpGuard support for installation
-// 2018-03-08 v1.1
+// 2022-06-13 v1.1.1
+
+// Changelog:
+// v1.1.1 - updated ProgramOutputStdout to support larger incoming byte arrays
 
 // Required permissions:
 // Service user must be able to run the following commands:
@@ -71,7 +74,10 @@ function main(targetHost) {
     // function to extract stdout from the runCmd response
     let programOutputStdout = resp => {
         let [exit_status, _stdout, _stderr] = resp;
-        let stdout = String.fromCharCode.apply(null, _stdout);
+        let stdout = '';
+        for (var i=0; i < _stdout.byteLength; i++) {
+            stdout += String.fromCharCode(_stdout[i]);
+        }
         return stdout.trim();
     }
 


### PR DESCRIPTION
If the bytearray that comes back from a command is larger than the Node call stack size, passing it as an argument to apply will throw a call stack size exceeded error.

Processing it as a loop works for any size (tested up to 5MB).